### PR TITLE
feat: make a standalone component for Responsive YT video player

### DIFF
--- a/src/app/_shared/components/index.ts
+++ b/src/app/_shared/components/index.ts
@@ -1,0 +1,1 @@
+export * from './yt-video-player/yt-video-player.module';

--- a/src/app/_shared/components/yt-video-player/yt-video-player.component.html
+++ b/src/app/_shared/components/yt-video-player/yt-video-player.component.html
@@ -1,0 +1,1 @@
+<youtube-player [playerVars]="playerVars" videoId="{{videoId}}"></youtube-player>

--- a/src/app/_shared/components/yt-video-player/yt-video-player.component.scss
+++ b/src/app/_shared/components/yt-video-player/yt-video-player.component.scss
@@ -1,0 +1,23 @@
+// tricks for making embed iframe video responsive
+.app-yt-video-player {
+  display: block;
+  position: relative;
+  width: 100%;
+  padding: 0;
+  overflow: hidden;
+  &::before {
+    box-sizing: border-box;
+    padding-top: 56.25%; // aspect ratio of a video is 16:9. (9 is 56.25% of 16)
+    display: block;
+    content: "";
+  }
+  iframe{
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    border: 0;
+  }
+}

--- a/src/app/_shared/components/yt-video-player/yt-video-player.component.spec.ts
+++ b/src/app/_shared/components/yt-video-player/yt-video-player.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { YtVideoPlayerComponent } from './yt-video-player.component';
+
+describe('YtVideoPlayerComponent', () => {
+  let component: YtVideoPlayerComponent;
+  let fixture: ComponentFixture<YtVideoPlayerComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ YtVideoPlayerComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(YtVideoPlayerComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/_shared/components/yt-video-player/yt-video-player.component.ts
+++ b/src/app/_shared/components/yt-video-player/yt-video-player.component.ts
@@ -1,0 +1,25 @@
+import { Component, Input, OnInit, ViewEncapsulation } from '@angular/core';
+
+@Component({
+  selector: 'app-yt-video-player',
+  templateUrl: './yt-video-player.component.html',
+  styleUrls: ['./yt-video-player.component.scss'],
+  host: {
+    'class': 'app-yt-video-player'
+  },
+  encapsulation: ViewEncapsulation.None
+})
+export class YtVideoPlayerComponent implements OnInit {
+
+  @Input() videoId: string | undefined = undefined;
+
+  playerVars: YT.PlayerVars = {
+    rel: YT.RelatedVideos.Hide
+  };
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+}

--- a/src/app/_shared/components/yt-video-player/yt-video-player.component.ts
+++ b/src/app/_shared/components/yt-video-player/yt-video-player.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, OnInit, ViewEncapsulation } from '@angular/core';
+import { Component, Input, ViewEncapsulation } from '@angular/core';
 
 @Component({
   selector: 'app-yt-video-player',
@@ -9,17 +9,11 @@ import { Component, Input, OnInit, ViewEncapsulation } from '@angular/core';
   },
   encapsulation: ViewEncapsulation.None
 })
-export class YtVideoPlayerComponent implements OnInit {
+export class YtVideoPlayerComponent {
 
   @Input() videoId: string | undefined = undefined;
 
   playerVars: YT.PlayerVars = {
     rel: YT.RelatedVideos.Hide
   };
-
-  constructor() { }
-
-  ngOnInit(): void {
-  }
-
 }

--- a/src/app/_shared/components/yt-video-player/yt-video-player.module.ts
+++ b/src/app/_shared/components/yt-video-player/yt-video-player.module.ts
@@ -1,0 +1,16 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { YtVideoPlayerComponent } from './yt-video-player.component';
+import { YouTubePlayerModule } from '@angular/youtube-player';
+
+
+
+@NgModule({
+  declarations: [YtVideoPlayerComponent],
+  imports: [
+    CommonModule,
+    YouTubePlayerModule
+  ],
+  exports : [YtVideoPlayerComponent]
+})
+export class YtVideoPlayerModule { }

--- a/src/app/home/home.module.ts
+++ b/src/app/home/home.module.ts
@@ -1,6 +1,6 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { YouTubePlayerModule } from '@angular/youtube-player';
+import { YtVideoPlayerModule } from '../_shared/components';
 import { VideoBannerComponent } from './video-banner/video-banner.component';
 import { VideoItemComponent } from './video-item/video-item.component';
 import { VideoListingComponent } from './video-listing/video-listing.component';
@@ -13,7 +13,7 @@ const DECLARATIONS = [
 
 @NgModule({
   declarations: DECLARATIONS,
-  imports: [CommonModule, YouTubePlayerModule],
+  imports: [CommonModule, YtVideoPlayerModule],
   exports: DECLARATIONS,
 })
 export class HomeModule {}

--- a/src/app/home/video-banner/video-banner.component.html
+++ b/src/app/home/video-banner/video-banner.component.html
@@ -1,10 +1,12 @@
 <div class="flex flex-col lg:flex-row" *ngIf="ytVideo !== null">
-  <youtube-player videoId="{{ytVideo.videoId}}"></youtube-player>
-  <div class="lg:pl-5">
-    <h3 class="text-xl mt-4 font-medium leading-normal text-gray-800">
+  <div class="flex-grow">
+    <app-yt-video-player videoId="{{ytVideo.videoId}}"></app-yt-video-player>
+  </div>
+  <div class="w-full lg:w-96 lg:pl-5">
+    <h3 class="text-xl my-6 font-medium leading-normal text-gray-800 lg:mt-0">
       {{ytVideo.title}}
     </h3>
-    <p class="text-xl font-light leading-relaxed my-6 mb-4 max-h-96 overflow-hidden overflow-ellipsis" [innerText]="ytVideo.description"></p>
+    <p class="text-xl font-light leading-relaxed mb-6 max-h-96 overflow-hidden overflow-ellipsis" [innerText]="ytVideo.description"></p>
   </div>
 </div>
 <div class="flex" *ngIf="ytVideo === null">


### PR DESCRIPTION
- Create a reusable component for responsive YT video player with ratio **16:9**
- replace official YT player on Video Banner with the responsive YT video player

![localhost_4200_ (2)](https://user-images.githubusercontent.com/9744226/111039850-89cad480-8430-11eb-9304-5c1985433425.png)
