### PR TITLE
docs: added documentation on how to test pre rendered app locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,25 +15,36 @@ https://ngx-darija.netlify.app
 
 - Run `npm install netlify-cli -g`
 
-To fetch the `ngMorocco` video sessions you will need to create an API key and
-set up your dev environment for the `netlify function` to consume this API key.
+To fetch the `ngMorocco` video sessions you will need to create an API key and set up your dev environment for
+the `netlify function` to consume this API key.
 
-- follow [this instructions](https://developers.google.com/maps/documentation/maps-static/get-api-key?hl=en) to set up an API key
-  with your Google account
+- follow [this instructions](https://developers.google.com/maps/documentation/maps-static/get-api-key?hl=en) to set up
+  an API key with your Google account
 - add the GOOGLE_API_KEY to your env variables: `export GOOGLE_API_KEY='{{YOUR_API_KEY}}'`
 - run `netlify dev` from root directory
 
 # Test the pre rendered version locally
+
+Before being deployed, the app is pre rendered at build time, so we can quickly give a static version of the application
+as soon as a request hits the server. Then the javascript files that will take over the app are loaded in the
+background. Because of that the first load of the application may not behave the same as when it ran using the
+command `netlify dev`.
+
+**It is recommended to test changes as if there were on the server**
+
+## Build step
+
+- If you have a `netlify` account you can [link your site to this project](https://docs.netlify.com/cli/get-started/#installation)
+  and run `netlify build`
   
-  Before being deployed, the app is pre rendered at build time, so we can quickly give a static version of the application as soon
-  as a request hits the server. Then the javascript files that will take over the app are loaded in the background.
-  Because of that the first load of the application may not behave the same as 
-  when it ran using the command `netlify dev`. 
-  
-  **It is recommended to test changes as if there were on the server** by pre rendering the application using:
-  `netlify build` (If it's the first time running this command you will be asked to login and link a site
-  [more info here](https://docs.netlify.com/cli/get-started/#installation)). Then when the build is done, serve the 
-  dist folder using `netlify dev --dir dist/ngx-darija/browser`
+OR RUN
+
+- Shell `GOOGLE_API_KEY=AIzaSyB_xxxxxxxx NODE_ENV=production npm run serve-prerender`
+- PowerShell: `$env:GOOGLE_API_KEY="AIzaSyB_xxxxxxxx"; $env:NODE_ENV="production"; npm run serve-prerender`
+
+## Serve step
+
+`netlify dev --dir dist/ngx-darija/browser`
 
 # Build
 
@@ -47,7 +58,8 @@ set up your dev environment for the `netlify function` to consume this API key.
 
 Thanks for your contribution.
 
-If it's your first contribution to a public Github repo follow [this](https://github.com/firstcontributions/first-contributions).
+If it's your first contribution to a public Github repo
+follow [this](https://github.com/firstcontributions/first-contributions).
 
 Otherwise Just
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,18 @@ set up your dev environment for the `netlify function` to consume this API key.
 - add the GOOGLE_API_KEY to your env variables: `export GOOGLE_API_KEY='{{YOUR_API_KEY}}'`
 - run `netlify dev` from root directory
 
+# Test the pre rendered version locally
+  
+  Before being deployed, the app is pre rendered at build time, so we can quickly give a static version of the application as soon
+  as a request hits the server. Then the javascript files that will take over the app are loaded in the background.
+  Because of that the first load of the application may not behave the same as 
+  when it ran using the command `netlify dev`. 
+  
+  **It is recommended to test changes as if there were on the server** by pre rendering the application using:
+  `netlify build` (If it's the first time running this command you will be asked to login and link a site
+  [more info here](https://docs.netlify.com/cli/get-started/#installation)). Then when the build is done, serve the 
+  dist folder using `netlify dev --dir dist/ngx-darija/browser`
+
 # Build
 
 - Run `NODE_ENV npm run build`


### PR DESCRIPTION
I saw a lot of differences (especially on the first load) between when we use app in local compared to when it's prerendered and deployed on the server so I added some instructions on how to test the app prerendered like it is on the prod server